### PR TITLE
Startup Bugfix

### DIFF
--- a/XSplitScreen/Plugin.cs
+++ b/XSplitScreen/Plugin.cs
@@ -461,8 +461,7 @@ namespace Dodad.XSplitscreen
 			Patcher.Patch(chbOriginal, prefix: new HarmonyLib.HarmonyMethod(chbPatch));
 
 			// Nameplate color
-
-			var npcOriginal = typeof(RoR2.UI.Nameplate).GetMethod("SetBody", BindingFlags.Instance | BindingFlags.Public);
+			var npcOriginal = typeof(RoR2.UI.Nameplate).GetMethod("Initialize", BindingFlags.Instance | BindingFlags.Public);
 			var npcPatch = typeof(Plugin).GetMethod("Nameplate_SetBody", BindingFlags.Static | BindingFlags.NonPublic);
 
 			Patcher.Patch(npcOriginal, prefix: new HarmonyLib.HarmonyMethod(npcPatch));


### PR DESCRIPTION
ROR2.UI api changed. After the repo update (lol) and thanks to @Zenithrium on the discord. The culprit was located. I decompiled the current ror2 dll and found that `SetBody` was likely replaced with `Initialize` in `ROR2.UI.Nameplate` as it also just sets the Nameplate body to the parameter input.