### PR TITLE
Bugfix: Disappearing cursor

### DIFF
--- a/XSplitScreen/HookManager.cs
+++ b/XSplitScreen/HookManager.cs
@@ -276,8 +276,6 @@ namespace Dodad.XSplitscreen
 
 		private static void UpdateMultiplayerColors(bool isSplitscreenEnabled)
 		{
-			var field = typeof(ColorCatalog).GetField("multiplayerColors", BindingFlags.Static | BindingFlags.NonPublic);
-
 			var multiplayerColors = new Color[4]
 			{
 					new Color32(252, 62, 62, byte.MaxValue),
@@ -296,7 +294,7 @@ namespace Dodad.XSplitscreen
 					multiplayerColors[e] = SplitScreenSettings.GetUserModule<ColorSettingsModule>(localUsers[e].Profile?.fileName ?? string.Empty)?.Color ?? Color.white;
 			}
 
-			field.SetValue(null, multiplayerColors);
+			Plugin.UpdateMultiplayerColors(multiplayerColors);
 		}
 
 		private static MethodInfo CameraRigController_Start_Orig;

--- a/XSplitScreen/Plugin.cs
+++ b/XSplitScreen/Plugin.cs
@@ -38,6 +38,9 @@ namespace Dodad.XSplitscreen
 
         private static HGButton MainMenuTitleButton;
 
+
+		private static Color[] _multiplayerColors;
+
 		#endregion
 
 		//-----------------------------------------------------------------------------------------------------------
@@ -465,6 +468,12 @@ namespace Dodad.XSplitscreen
 			var npcPatch = typeof(Plugin).GetMethod("Nameplate_SetBody", BindingFlags.Static | BindingFlags.NonPublic);
 
 			Patcher.Patch(npcOriginal, prefix: new HarmonyLib.HarmonyMethod(npcPatch));
+
+			// Patch Get Multiplayer Color
+			var mcOriginal = typeof(RoR2.ColorCatalog).GetMethod("GetMultiplayerColor", BindingFlags.Static | BindingFlags.Public);
+			var mcPatch = typeof(Plugin).GetMethod("ColorCatalog_GetMultiplayerColor", BindingFlags.Static | BindingFlags.NonPublic);
+
+			Patcher.Patch(mcOriginal, prefix: new HarmonyLib.HarmonyMethod(mcPatch));
 		}
 
 		//-----------------------------------------------------------------------------------------------------------
@@ -634,6 +643,30 @@ namespace Dodad.XSplitscreen
 			{
 				__instance.baseColor = RoR2.ColorCatalog.GetMultiplayerColor(__0.master.playerCharacterMasterController.networkUser.localUser.id);
 			}
+		}
+
+		public static Color[] multiplayerColors
+		{
+			get => _multiplayerColors;
+		} 
+
+		public static void UpdateMultiplayerColors(Color[] colors)
+		{
+			_multiplayerColors = colors;
+		}
+
+        private static bool ColorCatalog_GetMultiplayerColor(int playerSlot, ref Color __result)
+		{
+			if (playerSlot >= 0 && playerSlot < multiplayerColors.Length)
+			{
+				 __result = multiplayerColors[playerSlot];
+			}
+			else
+			{
+				__result = Color.black;
+			}
+
+			return false;
 		}
 
 		private static bool CombatHealthBarViewer_SetLayoutHorizontal(RoR2.UI.CombatHealthBarViewer __instance)


### PR DESCRIPTION
`RoR2.ColorCatalog.multiplayerColors` is readonly. The compiler seems to make optimizations when compiling the function `RoR2.ColorCatalog.GetMultiplayerColor()` inlining the reference to `RoR2.ColorCatalog.multiplayerColors`. When the value was set in `HookManager.UpdateMultiplayerColors()`, the reference was changed and made the reference in
`RoR2.ColorCatalog.GetMultiplayerColor()` invalid.

To solve this, I store the multiplayer colors in this mod instead and patch `RoR2.ColorCatalog.GetMultiplayerColor()` to use that instead.

Looking at the dlls, it seems the only code that uses MultiplayerColors in the RoR2 managed is for the cursor so I don't forsee any issues with moving this over.